### PR TITLE
Install FMD as service

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ FMD is written in python2 and depends on `gstreamer0.10-python`. The recommendat
 
 To try FMD, just clone the repository. Run `python2 fmd/main.py start` and try the telnet example above. You may also interested in [FMC](https://github.com/hzqtc/fmc), a simple CLI client for FMD.
 
+FMD can be installed as service on Ubuntu by script `install.ubuntu.sh`. The FMD service automatically starts on system boots up. The service is run by root, so it reads configuration file from `/root/.fmd.conf`.
+
 ## Contribute
 
 This project is on its very ealy stage and requires lots of improvements. Any feedbacks, patches, forks and other helps are welcome.

--- a/fmd.init
+++ b/fmd.init
@@ -1,0 +1,42 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          fmd
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Douban.FM daemon
+# Description:       FMD plays music from Douban FM channels in background and
+#                    communicate with clients through (partially) PMD-compatible
+#                    protocol
+### END INIT INFO
+
+DAEMON=/var/lib/fmd/main.py
+NAME=fmd
+DESC="Douban.FM daemon"
+
+test -x $DAEMON || exit 0
+
+case "$1" in
+  start)
+        echo -n "Starting $DESC: "
+	python $DAEMON start
+        echo "done."
+        ;;
+  stop)
+        echo -n "Stopping $DESC: "
+	python $DAEMON stop
+        echo "done."
+        ;;
+  restart)
+        echo -n "Restarting $DESC: "
+	$DAEMON restart
+        echo "done."
+        ;;
+  *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/install.ubuntu.sh
+++ b/install.ubuntu.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Install fmd as service on Ubuntu.
+
+if [ `id -u` -ne 0 ]; then
+	echo "It must be executed by root."
+	exit 1
+fi
+
+# Copy files into /var/lib/fmd
+DEST_DIR=/var/lib/fmd
+mkdir -p $DEST_DIR
+SCRIPT_DIR=`dirname $0`
+cp $SCRIPT_DIR/* $DEST_DIR
+
+# Setup service
+mv $DEST_DIR/fmd.init /etc/init.d/fmd
+update-rc.d -f fmd remove
+update-rc.d fmd defaults
+
+# Start service
+service fmd start
+
+echo "Installation finished. You may change default configuration by modify file /root/.fmd.conf"


### PR DESCRIPTION
我增加了脚本将fmd安装为service，使得fmd在系统启动时能自动运行。启动脚步是为Ubuntu做的，在11.10上测试正常，估计在Debian/Ubuntu系列distro上都能用。

如果你觉得合适，可以把它合并到你的branch。
